### PR TITLE
Switch to absolute URLs for github users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ If you're interesting in contributing the project please join the [Boundless Wor
 
 The project is currently maintained by:
 
-* [nevir](../../../../nevir)
-* [jamesaustin](../../../../jamesaustin) - Wonderstruck
-* [olliepurkiss](../../../../olliepurkiss) - Wonderstruck
+* [nevir](https://github.com/nevir)
+* [jamesaustin](https://github.com/jamesaustin) - Wonderstruck
+* [olliepurkiss](https://github.com/olliepurkiss) - Wonderstruck
 
 ## License
 


### PR DESCRIPTION
This'll be clearer for folk that are looking at the README while somewhere other than GH, I think

@jamesaustin sneaky trixy use of `../`'s stop-once-it-reaches-the-domain behavior though!
