### PR TITLE
New "Standard" caves

### DIFF
--- a/config/noise3d/Caves/Standard.json
+++ b/config/noise3d/Caves/Standard.json
@@ -1,0 +1,385 @@
+{
+   "@collapsed" : false,
+   "@configType" : "NOISE3D",
+   "@name" : "Standard",
+   "@position" : [ 7932, 8160 ],
+   "@scroll" : [ 8531.38671875, 8364.00390625, 0 ],
+   "@toggle-test" : false,
+   "@toggle-world" : false,
+   "@unlinked" : [],
+   "@version" : 11,
+   "noise3d" : {
+      "fun" : {
+         "@collapsed" : false,
+         "@name" : "Sum 3D",
+         "@position" : [ 8260, 8057 ],
+         "frequency" : [ 1, 1, 1 ],
+         "terms" : [
+            {
+               "fun" : {
+                  "@collapsed" : false,
+                  "@name" : "Remap 3D",
+                  "@position" : [ 8584, 7861 ],
+                  "clamp" : false,
+                  "clampPower" : 5,
+                  "frequency" : [ 0.85000002384185791, 1.3000000715255737, 0.85000002384185791 ],
+                  "fun" : {
+                     "@collapsed" : false,
+                     "@name" : "Absolute 3D",
+                     "@position" : [ 8867, 7896 ],
+                     "frequency" : [ 1, 1, 1 ],
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Perlin 3D",
+                        "@position" : [ 9150, 7893 ],
+                        "frequency" : [ 0.60000002384185791, 1, 0.60000002384185791 ],
+                        "offset" : [ 448.32843017578125, 346.37640380859375, -19.147209167480469 ],
+                        "offset-hash" : "R9B7CPWpgVVxOajE",
+                        "type" : "perlin"
+                     },
+                     "type" : "absolute"
+                  },
+                  "max" : 1,
+                  "min" : -1,
+                  "type" : "remap"
+               },
+               "multiplier" : 1,
+               "power" : 1
+            },
+            {
+               "fun" : {
+                  "@collapsed" : false,
+                  "@name" : "Fractal 3D",
+                  "@position" : [ 8584, 8053 ],
+                  "frequency" : [ 1, 1, 1 ],
+                  "fun" : {
+                     "@collapsed" : false,
+                     "@name" : "Simplex 3D",
+                     "@position" : [ 8867, 8242 ],
+                     "frequency" : [ 1, 1, 1 ],
+                     "offset" : [ 924.04388427734375, 368.8262939453125, -312.59457397460938 ],
+                     "offset-hash" : "OC10oVJjrfZwGokm",
+                     "type" : "simplex"
+                  },
+                  "octaves" : [
+                     {
+                        "multiplier" : 0.20000000298023224,
+                        "offset" : [ -175.63160705566406, 380.31271362304688, -366.65362548828125 ],
+                        "offset-hash" : "chYR6AQIfQaBZ66C",
+                        "scale" : 2
+                     },
+                     {
+                        "multiplier" : 0.30000001192092896,
+                        "offset" : [ 1169.5068359375, 223.89822387695312, -192.4222412109375 ],
+                        "offset-hash" : "34rN9UiQx2YHHsTI",
+                        "scale" : 4
+                     },
+                     {
+                        "multiplier" : 0.30000001192092896,
+                        "offset" : [ 359.94833374023438, -81.593170166015625, -335.11196899414062 ],
+                        "offset-hash" : "r17CmgKbMSR8WAY7",
+                        "scale" : 6
+                     },
+                     {
+                        "multiplier" : 0.20000000298023224,
+                        "offset" : [ -206.68669128417969, 186.20823669433594, -356.202880859375 ],
+                        "offset-hash" : "K3p32Rk4ejgwL0DA",
+                        "scale" : 8
+                     }
+                  ],
+                  "type" : "fractal"
+               },
+               "multiplier" : 0.25,
+               "power" : 1
+            }
+         ],
+         "type" : "sum"
+      },
+      "links" : [
+         {
+            "blockConstraint" : 162208256,
+            "blockDefault" : "",
+            "checkDefault" : true,
+            "linkPath" : [
+               {
+                  "index" : -1,
+                  "name" : "noise3d"
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "terms"
+               },
+               {
+                  "index" : 0,
+                  "name" : ""
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "frequency"
+               },
+               {
+                  "index" : -1,
+                  "name" : "@y"
+               }
+            ],
+            "linkType" : "LT:CUSTOM_SLIDER",
+            "name" : "slope",
+            "shortPath" : "Remap 3D.frequency.@y",
+            "sliderCheck" : false,
+            "sliderDefault" : 1.3000000715255737,
+            "sliderMax" : 2,
+            "sliderMin" : 0,
+            "sliderStep" : 0.0010000000474974513
+         },
+         {
+            "blockConstraint" : 1453148896,
+            "blockDefault" : "",
+            "checkDefault" : true,
+            "linkPath" : [
+               {
+                  "index" : -1,
+                  "name" : "noise3d"
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "terms"
+               },
+               {
+                  "index" : 1,
+                  "name" : ""
+               },
+               {
+                  "index" : -1,
+                  "name" : "multiplier"
+               }
+            ],
+            "linkType" : "LT:CUSTOM_SLIDER",
+            "name" : "roughness",
+            "shortPath" : "Sum 3D.multiplier",
+            "sliderCheck" : false,
+            "sliderDefault" : 0.25,
+            "sliderMax" : 2,
+            "sliderMin" : -2,
+            "sliderStep" : 0.0010000000474974513
+         }
+      ]
+   },
+   "seed" : "I has a seed!",
+   "sharedConfig" : {
+      "worldSize" : 288
+   },
+   "test" : {
+      "@collapsed" : false,
+      "@name" : "Reference 3D",
+      "@position" : [ 8260, 8560 ],
+      "embedded" : {
+         "@collapsed" : false,
+         "@configType" : "NOISE3D",
+         "@name" : "Standard",
+         "@position" : [ 7932, 8160 ],
+         "@toggle-test" : false,
+         "@toggle-world" : false,
+         "@version" : 11,
+         "noise3d" : {
+            "fun" : {
+               "@collapsed" : false,
+               "@name" : "Sum 3D",
+               "@position" : [ 8260, 8057 ],
+               "frequency" : [ 1, 1, 1 ],
+               "terms" : [
+                  {
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Remap 3D",
+                        "@position" : [ 8584, 7861 ],
+                        "clamp" : false,
+                        "clampPower" : 5,
+                        "frequency" : [ 0.85000002384185791, 1.3000000715255737, 0.85000002384185791 ],
+                        "fun" : {
+                           "@collapsed" : false,
+                           "@name" : "Absolute 3D",
+                           "@position" : [ 8867, 7896 ],
+                           "frequency" : [ 1, 1, 1 ],
+                           "fun" : {
+                              "@collapsed" : false,
+                              "@name" : "Perlin 3D",
+                              "@position" : [ 9150, 7893 ],
+                              "frequency" : [ 0.60000002384185791, 1, 0.60000002384185791 ],
+                              "offset" : [ 448.32843017578125, 346.37640380859375, -19.147209167480469 ],
+                              "offset-hash" : "R9B7CPWpgVVxOajE",
+                              "type" : "perlin"
+                           },
+                           "type" : "absolute"
+                        },
+                        "max" : 1,
+                        "min" : -1,
+                        "type" : "remap"
+                     },
+                     "multiplier" : 1,
+                     "power" : 1
+                  },
+                  {
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Fractal 3D",
+                        "@position" : [ 8584, 8053 ],
+                        "frequency" : [ 1, 1, 1 ],
+                        "fun" : {
+                           "@collapsed" : false,
+                           "@name" : "Simplex 3D",
+                           "@position" : [ 8867, 8242 ],
+                           "frequency" : [ 1, 1, 1 ],
+                           "offset" : [ 924.04388427734375, 368.8262939453125, -312.59457397460938 ],
+                           "offset-hash" : "OC10oVJjrfZwGokm",
+                           "type" : "simplex"
+                        },
+                        "octaves" : [
+                           {
+                              "multiplier" : 0.20000000298023224,
+                              "offset" : [ -175.63160705566406, 380.31271362304688, -366.65362548828125 ],
+                              "offset-hash" : "chYR6AQIfQaBZ66C",
+                              "scale" : 2
+                           },
+                           {
+                              "multiplier" : 0.30000001192092896,
+                              "offset" : [ 1169.5068359375, 223.89822387695312, -192.4222412109375 ],
+                              "offset-hash" : "34rN9UiQx2YHHsTI",
+                              "scale" : 4
+                           },
+                           {
+                              "multiplier" : 0.30000001192092896,
+                              "offset" : [ 359.94833374023438, -81.593170166015625, -335.11196899414062 ],
+                              "offset-hash" : "r17CmgKbMSR8WAY7",
+                              "scale" : 6
+                           },
+                           {
+                              "multiplier" : 0.20000000298023224,
+                              "offset" : [ -206.68669128417969, 186.20823669433594, -356.202880859375 ],
+                              "offset-hash" : "K3p32Rk4ejgwL0DA",
+                              "scale" : 8
+                           }
+                        ],
+                        "type" : "fractal"
+                     },
+                     "multiplier" : 0.25,
+                     "power" : 1
+                  }
+               ],
+               "type" : "sum"
+            },
+            "links" : [
+               {
+                  "blockConstraint" : 162208256,
+                  "blockDefault" : "",
+                  "checkDefault" : true,
+                  "linkPath" : [
+                     {
+                        "index" : -1,
+                        "name" : "noise3d"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "terms"
+                     },
+                     {
+                        "index" : 0,
+                        "name" : ""
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "frequency"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "@y"
+                     }
+                  ],
+                  "linkType" : "LT:CUSTOM_SLIDER",
+                  "name" : "slope",
+                  "shortPath" : "Remap 3D.frequency.@y",
+                  "sliderCheck" : false,
+                  "sliderDefault" : 1.3000000715255737,
+                  "sliderMax" : 2,
+                  "sliderMin" : 0,
+                  "sliderStep" : 0.0010000000474974513
+               },
+               {
+                  "blockConstraint" : 1453148896,
+                  "blockDefault" : "",
+                  "checkDefault" : true,
+                  "linkPath" : [
+                     {
+                        "index" : -1,
+                        "name" : "noise3d"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "terms"
+                     },
+                     {
+                        "index" : 1,
+                        "name" : ""
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "multiplier"
+                     }
+                  ],
+                  "linkType" : "LT:CUSTOM_SLIDER",
+                  "name" : "roughness",
+                  "shortPath" : "Sum 3D.multiplier",
+                  "sliderCheck" : false,
+                  "sliderDefault" : 0.25,
+                  "sliderMax" : 2,
+                  "sliderMin" : -2,
+                  "sliderStep" : 0.0010000000474974513
+               }
+            ]
+         },
+         "seed" : "I has a seed!",
+         "sharedConfig" : {
+            "worldSize" : 288
+         },
+         "test" : {
+            "@collapsed" : false,
+            "@name" : "Reference 3D",
+            "@position" : [ 8260, 8560 ],
+            "frequency" : [ 1, 1, 1 ],
+            "offset" : [ 43.683452606201172, 197.92280578613281, -140.19082641601562 ],
+            "offset-hash" : "vsl5qH74m2bt8IFq",
+            "type" : "reference"
+         }
+      },
+      "frequency" : [ 1, 1, 1 ],
+      "links" : [],
+      "offset" : [ 43.683452606201172, 197.92280578613281, -140.19082641601562 ],
+      "offset-hash" : "vsl5qH74m2bt8IFq",
+      "reference" : "",
+      "tick" : 0,
+      "type" : "reference"
+   }
+}


### PR DESCRIPTION
These new caves are a bit more beginner friendly than our existing ones (influenced by #12):

* They slope far more gradually
* Configured to give a good result at default cave settings for a biome (threshold of 0.0, surface shrink of 1.0)
* A few settings are exposed for more fine grained control
* I'm trying a new organization strategy by introducing a `Caves/` folder under `noise3d`

![image](https://cloud.githubusercontent.com/assets/41373/26030900/348889b4-3816-11e7-8bd8-eb3564965055.png)
