### PR TITLE
Consistent Offset node (2d, 3d)

### DIFF
--- a/config/noise2d/offset.json
+++ b/config/noise2d/offset.json
@@ -2,8 +2,8 @@
    "@collapsed" : false,
    "@configType" : "NOISE2D",
    "@name" : "Offset",
-   "@position" : [ 7932, 8160 ],
-   "@scroll" : [ 8634.84765625, 8314.234375, 0 ],
+   "@position" : [ 7930, 8132 ],
+   "@scroll" : [ 8299.5205078125, 8297.578125, 0.22499997913837433 ],
    "@toggle-test" : true,
    "@toggle-world" : false,
    "@unlinked" : [],
@@ -12,88 +12,62 @@
       "fun" : {
          "@collapsed" : false,
          "@name" : "Sum 2D",
-         "@position" : [ 8238, 8063 ],
+         "@position" : [ 8237, 8023 ],
          "frequency" : 1,
+         "seed" : 0,
+         "seed-combine" : false,
          "seed-hash" : "",
          "terms" : [
             {
-               "fun" : {
-                  "@collapsed" : false,
-                  "@name" : "Remap 2D",
-                  "@position" : [ 8534, 8056 ],
-                  "clamp" : false,
-                  "clampPower" : 5,
-                  "frequency" : 1,
-                  "fun" : null,
-                  "max" : 1,
-                  "min" : -1,
-                  "seed-hash" : "",
-                  "type" : "remap"
-               },
+               "fun" : null,
                "multiplier" : 1,
-               "power" : 1,
-               "seed-hash" : ""
+               "power" : 1
             },
             {
                "fun" : {
                   "@collapsed" : false,
                   "@name" : "Constant 2D",
-                  "@position" : [ 8534, 8225 ],
+                  "@position" : [ 8519, 8123 ],
                   "frequency" : 1,
-                  "offset" : [ 159.45677185058594, 110.11886596679688 ],
-                  "offset-hash" : "x2I4Suy87ZQ8PYEz",
-                  "seed-hash" : "x2I4Suy87ZQ8PYEz",
                   "type" : "constant",
                   "value" : 0
                },
                "multiplier" : 1,
-               "power" : 1,
-               "seed-hash" : ""
+               "power" : 1
             }
          ],
          "type" : "sum"
       },
       "links" : [
          {
-            "blockConstraint" : 173316608,
+            "blockConstraint" : 116025168,
             "blockDefault" : "",
             "checkDefault" : false,
             "linkPath" : [
                {
                   "index" : -1,
-                  "name" : "noise2d",
-                  "seed-hash" : ""
+                  "name" : "noise2d"
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                },
                {
                   "index" : -1,
-                  "name" : "terms",
-                  "seed-hash" : ""
+                  "name" : "terms"
                },
                {
                   "index" : 0,
-                  "name" : "",
-                  "seed-hash" : ""
+                  "name" : ""
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
-               },
-               {
-                  "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                }
             ],
             "linkType" : "LT:NOISE_2D",
-            "name" : "function",
-            "seed-hash" : "",
-            "shortPath" : "Remap 2D.base",
+            "name" : "base",
+            "shortPath" : "Sum 2D.function",
             "sliderCheck" : false,
             "sliderDefault" : 0,
             "sliderMax" : 0,
@@ -107,38 +81,31 @@
             "linkPath" : [
                {
                   "index" : -1,
-                  "name" : "noise2d",
-                  "seed-hash" : ""
+                  "name" : "noise2d"
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                },
                {
                   "index" : -1,
-                  "name" : "terms",
-                  "seed-hash" : ""
+                  "name" : "terms"
                },
                {
                   "index" : 1,
-                  "name" : "",
-                  "seed-hash" : ""
+                  "name" : ""
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                },
                {
                   "index" : -1,
-                  "name" : "value",
-                  "seed-hash" : ""
+                  "name" : "value"
                }
             ],
             "linkType" : "LT:CUSTOM_SLIDER",
             "name" : "offset",
-            "seed-hash" : "",
             "shortPath" : "Constant 2D.value",
             "sliderCheck" : false,
             "sliderDefault" : 0,
@@ -146,8 +113,7 @@
             "sliderMin" : -1,
             "sliderStep" : 0.0010000000474974513
          }
-      ],
-      "seed-hash" : ""
+      ]
    },
    "seed" : "I has a seed!",
    "seed-hash" : "",
@@ -158,101 +124,75 @@
    "test" : {
       "@collapsed" : false,
       "@name" : "Reference 2D",
-      "@position" : [ 8238, 8353 ],
+      "@position" : [ 8237, 8329 ],
       "embedded" : {
          "@collapsed" : false,
          "@configType" : "NOISE2D",
          "@name" : "Offset",
-         "@position" : [ 7932, 8160 ],
+         "@position" : [ 7930, 8132 ],
          "@toggle-test" : true,
          "@toggle-world" : false,
-         "@version" : 11,
+         "@version" : 18,
          "noise2d" : {
             "fun" : {
                "@collapsed" : false,
                "@name" : "Sum 2D",
-               "@position" : [ 8238, 8063 ],
+               "@position" : [ 8237, 8023 ],
                "frequency" : 1,
+               "seed" : 0,
+               "seed-combine" : false,
                "seed-hash" : "",
                "terms" : [
                   {
-                     "fun" : {
-                        "@collapsed" : false,
-                        "@name" : "Remap 2D",
-                        "@position" : [ 8534, 8056 ],
-                        "clamp" : false,
-                        "clampPower" : 5,
-                        "frequency" : 1,
-                        "fun" : null,
-                        "max" : 1,
-                        "min" : -1,
-                        "seed-hash" : "",
-                        "type" : "remap"
-                     },
+                     "fun" : null,
                      "multiplier" : 1,
-                     "power" : 1,
-                     "seed-hash" : ""
+                     "power" : 1
                   },
                   {
                      "fun" : {
                         "@collapsed" : false,
                         "@name" : "Constant 2D",
-                        "@position" : [ 8534, 8225 ],
+                        "@position" : [ 8519, 8123 ],
                         "frequency" : 1,
-                        "offset" : [ 159.45677185058594, 110.11886596679688 ],
-                        "offset-hash" : "x2I4Suy87ZQ8PYEz",
-                        "seed-hash" : "x2I4Suy87ZQ8PYEz",
                         "type" : "constant",
                         "value" : 0
                      },
                      "multiplier" : 1,
-                     "power" : 1,
-                     "seed-hash" : ""
+                     "power" : 1
                   }
                ],
                "type" : "sum"
             },
             "links" : [
                {
-                  "blockConstraint" : 173316608,
+                  "blockConstraint" : 116025168,
                   "blockDefault" : "",
                   "checkDefault" : false,
                   "linkPath" : [
                      {
                         "index" : -1,
-                        "name" : "noise2d",
-                        "seed-hash" : ""
+                        "name" : "noise2d"
                      },
                      {
                         "index" : -1,
-                        "name" : "fun",
-                        "seed-hash" : ""
+                        "name" : "fun"
                      },
                      {
                         "index" : -1,
-                        "name" : "terms",
-                        "seed-hash" : ""
+                        "name" : "terms"
                      },
                      {
                         "index" : 0,
-                        "name" : "",
-                        "seed-hash" : ""
+                        "name" : ""
                      },
                      {
                         "index" : -1,
-                        "name" : "fun",
-                        "seed-hash" : ""
-                     },
-                     {
-                        "index" : -1,
-                        "name" : "fun",
-                        "seed-hash" : ""
+                        "name" : "fun"
                      }
                   ],
                   "linkType" : "LT:NOISE_2D",
-                  "name" : "function",
-                  "seed-hash" : "",
-                  "shortPath" : "Remap 2D.base",
+                  "name" : "base",
+                  "shortPath" : "Sum 2D.function",
                   "sliderCheck" : false,
                   "sliderDefault" : 0,
                   "sliderMax" : 0,
@@ -266,38 +206,31 @@
                   "linkPath" : [
                      {
                         "index" : -1,
-                        "name" : "noise2d",
-                        "seed-hash" : ""
+                        "name" : "noise2d"
                      },
                      {
                         "index" : -1,
-                        "name" : "fun",
-                        "seed-hash" : ""
+                        "name" : "fun"
                      },
                      {
                         "index" : -1,
-                        "name" : "terms",
-                        "seed-hash" : ""
+                        "name" : "terms"
                      },
                      {
                         "index" : 1,
-                        "name" : "",
-                        "seed-hash" : ""
+                        "name" : ""
                      },
                      {
                         "index" : -1,
-                        "name" : "fun",
-                        "seed-hash" : ""
+                        "name" : "fun"
                      },
                      {
                         "index" : -1,
-                        "name" : "value",
-                        "seed-hash" : ""
+                        "name" : "value"
                      }
                   ],
                   "linkType" : "LT:CUSTOM_SLIDER",
                   "name" : "offset",
-                  "seed-hash" : "",
                   "shortPath" : "Constant 2D.value",
                   "sliderCheck" : false,
                   "sliderDefault" : 0,
@@ -305,23 +238,20 @@
                   "sliderMin" : -1,
                   "sliderStep" : 0.0010000000474974513
                }
-            ],
-            "seed-hash" : ""
+            ]
          },
          "seed" : "I has a seed!",
-         "seed-hash" : "",
          "sharedConfig" : {
-            "seed-hash" : "",
             "worldSize" : 288
          },
          "test" : {
             "@collapsed" : false,
             "@name" : "Reference 2D",
-            "@position" : [ 8238, 8353 ],
+            "@position" : [ 8237, 8329 ],
             "frequency" : 1,
-            "offset" : [ 96.699470520019531, 341.17831420898438 ],
-            "offset-hash" : "zGQuor9d4wQhgQ1i",
-            "seed-hash" : "zGQuor9d4wQhgQ1i",
+            "seed" : 17984836586847642466,
+            "seed-combine" : true,
+            "seed-hash" : "EoTHIcVAvnXJndKg",
             "type" : "reference"
          }
       },
@@ -331,90 +261,74 @@
             "linkPath" : [
                {
                   "index" : -1,
-                  "name" : "noise2d",
-                  "seed-hash" : ""
+                  "name" : "noise2d"
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                },
                {
                   "index" : -1,
-                  "name" : "terms",
-                  "seed-hash" : ""
+                  "name" : "terms"
                },
                {
                   "index" : 0,
-                  "name" : "",
-                  "seed-hash" : ""
+                  "name" : ""
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
-               },
-               {
-                  "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                }
             ],
             "linkType" : "LT:NOISE_2D",
             "nodeValue" : {
                "@collapsed" : false,
-               "@name" : "Perlin 2D",
-               "@position" : [ 8520, 8373 ],
-               "frequency" : 1,
-               "offset" : [ 328.5755615234375, 31.274721145629883 ],
-               "offset-hash" : "PjyzNFOpQ3Bz6lL7",
-               "seed-hash" : "PjyzNFOpQ3Bz6lL7",
-               "type" : "perlin"
-            },
-            "seed-hash" : ""
+               "@name" : "Wave 2D",
+               "@position" : [ 8521, 8332 ],
+               "directions" : "xz",
+               "frequency" : 0.25,
+               "seed" : 6634747913622932304,
+               "seed-combine" : true,
+               "seed-hash" : "9uATxvpTEBXNIrZL",
+               "type" : "wave",
+               "waveType" : "sine"
+            }
          },
          {
             "linkPath" : [
                {
                   "index" : -1,
-                  "name" : "noise2d",
-                  "seed-hash" : ""
+                  "name" : "noise2d"
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                },
                {
                   "index" : -1,
-                  "name" : "terms",
-                  "seed-hash" : ""
+                  "name" : "terms"
                },
                {
                   "index" : 1,
-                  "name" : "",
-                  "seed-hash" : ""
+                  "name" : ""
                },
                {
                   "index" : -1,
-                  "name" : "fun",
-                  "seed-hash" : ""
+                  "name" : "fun"
                },
                {
                   "index" : -1,
-                  "name" : "value",
-                  "seed-hash" : ""
+                  "name" : "value"
                }
             ],
             "linkType" : "LT:CUSTOM_SLIDER",
-            "seed-hash" : "",
-            "sliderValue" : -1
+            "sliderValue" : 1
          }
       ],
-      "offset" : [ 96.699470520019531, 341.17831420898438 ],
-      "offset-hash" : "zGQuor9d4wQhgQ1i",
       "reference" : "",
-      "seed-hash" : "zGQuor9d4wQhgQ1i",
+      "seed" : 17984836586847642466,
+      "seed-combine" : true,
+      "seed-hash" : "EoTHIcVAvnXJndKg",
       "tick" : 0,
       "type" : "reference"
    }

--- a/config/noise3d/offset.json
+++ b/config/noise3d/offset.json
@@ -1,0 +1,322 @@
+{
+   "@collapsed" : false,
+   "@configType" : "NOISE3D",
+   "@name" : "Offset",
+   "@position" : [ 7932, 8160 ],
+   "@scroll" : [ 8193.2890625, 8310.10546875, 0 ],
+   "@toggle-test" : false,
+   "@toggle-world" : false,
+   "@unlinked" : [],
+   "@version" : 18,
+   "noise3d" : {
+      "fun" : {
+         "@collapsed" : false,
+         "@name" : "Sum 3D",
+         "@position" : [ 8234, 8046 ],
+         "frequency" : [ 1, 1 ],
+         "seed" : 0,
+         "seed-combine" : true,
+         "seed-hash" : "",
+         "terms" : [
+            {
+               "fun" : null,
+               "multiplier" : 1,
+               "power" : 1
+            },
+            {
+               "fun" : {
+                  "@collapsed" : false,
+                  "@name" : "Constant 3D",
+                  "@position" : [ 8517, 8146 ],
+                  "frequency" : [ 1, 1 ],
+                  "type" : "constant",
+                  "value" : 0
+               },
+               "multiplier" : 1,
+               "power" : 1
+            }
+         ],
+         "type" : "sum"
+      },
+      "links" : [
+         {
+            "blockConstraint" : 8645152,
+            "blockDefault" : "",
+            "checkDefault" : false,
+            "linkPath" : [
+               {
+                  "index" : -1,
+                  "name" : "noise3d"
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "terms"
+               },
+               {
+                  "index" : 0,
+                  "name" : ""
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               }
+            ],
+            "linkType" : "LT:NOISE_3D",
+            "name" : "base",
+            "shortPath" : "Sum 3D.function",
+            "sliderCheck" : false,
+            "sliderDefault" : 0,
+            "sliderMax" : 0,
+            "sliderMin" : 0,
+            "sliderStep" : 0
+         },
+         {
+            "blockConstraint" : 35871296,
+            "blockDefault" : "",
+            "checkDefault" : false,
+            "linkPath" : [
+               {
+                  "index" : -1,
+                  "name" : "noise3d"
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "terms"
+               },
+               {
+                  "index" : 1,
+                  "name" : ""
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "value"
+               }
+            ],
+            "linkType" : "LT:CUSTOM_SLIDER",
+            "name" : "offset",
+            "shortPath" : "Constant 3D.value",
+            "sliderCheck" : false,
+            "sliderDefault" : 0,
+            "sliderMax" : 1,
+            "sliderMin" : -1,
+            "sliderStep" : 0.0010000000474974513
+         }
+      ]
+   },
+   "seed" : "I has a seed!",
+   "sharedConfig" : {
+      "worldSize" : 288
+   },
+   "test" : {
+      "@collapsed" : false,
+      "@name" : "Reference 3D",
+      "@position" : [ 8234, 8375 ],
+      "embedded" : {
+         "@collapsed" : false,
+         "@configType" : "NOISE3D",
+         "@name" : "Offset",
+         "@position" : [ 7932, 8160 ],
+         "@toggle-test" : false,
+         "@toggle-world" : false,
+         "@version" : 18,
+         "noise3d" : {
+            "fun" : {
+               "@collapsed" : false,
+               "@name" : "Sum 3D",
+               "@position" : [ 8234, 8046 ],
+               "frequency" : [ 1, 1 ],
+               "seed" : 0,
+               "seed-combine" : true,
+               "seed-hash" : "",
+               "terms" : [
+                  {
+                     "fun" : null,
+                     "multiplier" : 1,
+                     "power" : 1
+                  },
+                  {
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Constant 3D",
+                        "@position" : [ 8517, 8146 ],
+                        "frequency" : [ 1, 1 ],
+                        "type" : "constant",
+                        "value" : 0
+                     },
+                     "multiplier" : 1,
+                     "power" : 1
+                  }
+               ],
+               "type" : "sum"
+            },
+            "links" : [
+               {
+                  "blockConstraint" : 8645152,
+                  "blockDefault" : "",
+                  "checkDefault" : false,
+                  "linkPath" : [
+                     {
+                        "index" : -1,
+                        "name" : "noise3d"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "terms"
+                     },
+                     {
+                        "index" : 0,
+                        "name" : ""
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     }
+                  ],
+                  "linkType" : "LT:NOISE_3D",
+                  "name" : "base",
+                  "shortPath" : "Sum 3D.function",
+                  "sliderCheck" : false,
+                  "sliderDefault" : 0,
+                  "sliderMax" : 0,
+                  "sliderMin" : 0,
+                  "sliderStep" : 0
+               },
+               {
+                  "blockConstraint" : 35871296,
+                  "blockDefault" : "",
+                  "checkDefault" : false,
+                  "linkPath" : [
+                     {
+                        "index" : -1,
+                        "name" : "noise3d"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "terms"
+                     },
+                     {
+                        "index" : 1,
+                        "name" : ""
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "value"
+                     }
+                  ],
+                  "linkType" : "LT:CUSTOM_SLIDER",
+                  "name" : "offset",
+                  "shortPath" : "Constant 3D.value",
+                  "sliderCheck" : false,
+                  "sliderDefault" : 0,
+                  "sliderMax" : 1,
+                  "sliderMin" : -1,
+                  "sliderStep" : 0.0010000000474974513
+               }
+            ]
+         },
+         "seed" : "I has a seed!",
+         "sharedConfig" : {
+            "worldSize" : 288
+         },
+         "test" : {
+            "@collapsed" : false,
+            "@name" : "Reference 3D",
+            "@position" : [ 8234, 8375 ],
+            "frequency" : [ 1, 1 ],
+            "seed" : 7124240366906756952,
+            "seed-combine" : true,
+            "seed-hash" : "KwnOlWzDAkfQzyT4",
+            "type" : "reference"
+         }
+      },
+      "frequency" : [ 1, 1 ],
+      "links" : [
+         {
+            "linkPath" : [
+               {
+                  "index" : -1,
+                  "name" : "noise3d"
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "terms"
+               },
+               {
+                  "index" : 0,
+                  "name" : ""
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               }
+            ],
+            "linkType" : "LT:NOISE_3D",
+            "nodeValue" : null
+         },
+         {
+            "linkPath" : [
+               {
+                  "index" : -1,
+                  "name" : "noise3d"
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "terms"
+               },
+               {
+                  "index" : 1,
+                  "name" : ""
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "value"
+               }
+            ],
+            "linkType" : "LT:CUSTOM_SLIDER",
+            "sliderValue" : 0
+         }
+      ],
+      "reference" : "",
+      "seed" : 7124240366906756952,
+      "seed-combine" : true,
+      "seed-hash" : "KwnOlWzDAkfQzyT4",
+      "tick" : 0,
+      "type" : "reference"
+   }
+}


### PR DESCRIPTION
Fixes up the Offset node to not require an intermediate remap node (was working around a past bug), and adds offset 3d